### PR TITLE
Move JayAddLink from Text-filter to HTML and ASCII converter

### DIFF
--- a/lib/markdown_to_ascii.rb
+++ b/lib/markdown_to_ascii.rb
@@ -370,6 +370,14 @@ module Kramdown
         ""
       end
 
+      def convert_action_item(el, indent)
+        "-->(#{el.options[:assignee]})"
+      end
+
+      def convert_issue_link(el, indent)
+        el.options[:match]
+      end
+
       def find_first_type(el, type)
         return el if [type].flatten.include?(el.type)
         el.children.each do |c|


### PR DESCRIPTION
Example:

```
+ item1 -->(someone !:0001)
+ item2 nomlab/jay/#1
```

to HTML

```
<ol data-linenum="1">
  <li class="bullet-list-item" data-linenum="1">
    <span class="bullet-list-marker">(1)</span>item1 <a href="" class="action-item" data-action-item="0001" data-linenum="1">–&gt;(someone !:0001)</a>
  </li>
  <li class="bullet-list-item" data-linenum="2">
    <span class="bullet-list-marker">(2)</span>item2 <a href="https://github.com/nomlab/jay/issues/1" class="github-issue" data-linenum="2">nomlab/jay/#1</a>
  </li>
</ol>
```

to ASCII

```
(1) item1 -->(someone)
(2) item2 nomlab/jay/#1
```
